### PR TITLE
Adds DAP reporting

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -80,3 +80,6 @@
   ga('send', 'pageview');
 
 </script>
+
+<!-- Digital Analytics Program roll-up, see https://analytics.usa.gov for data -->
+<script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA"></script>


### PR DESCRIPTION
This gets the site reporting to DAP with:

```
<script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA"></script>
```

I specified a `GSA` value for the `agency` field.

This takes advantage of the DAP's new [centrally hosted JavaScript code](https://www.digitalgov.gov/2015/08/14/secure-central-hosting-for-the-digital-analytics-program/), which means 18f.gsa.gov will automatically get security updates, new features, and other bugfixes automatically.