### PR TITLE
Better Call to Action for PIF Eagle

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -35,7 +35,10 @@
                                                 `W###@#N#/b
                                                  .#mj#X~YM#
                                                  ~`#WdD~  Y!
-                                                 `'_|#f--          built by Presidential Innovation Fellows (http://pif.gov)
+                                                 `'_|#f--
+
+  Like code? Want to make America more awesome?
+  Apply to be a Presidential Innovation Fellow: https://apply.pif.gov/
   -->
   <head>
   <meta charset="utf-8">
@@ -47,7 +50,7 @@
 
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" />
-  
+
   {% if page.url == "/404.html" %}
     <meta http-equiv="refresh" content="5; url=/">
   {% endif %}


### PR DESCRIPTION
Adds content and a link directly to the Apply page under the PIF eagle.

* Add content and link to Apply page in <head>

https://trello.com/c/7yyNItH1/16-come-up-with-better-call-to-action-for-pif-gov-header-comment