### PR TITLE
Move tag manager code from footer to header; fixes #121

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -16,7 +16,7 @@
               <li><h4><a href="{{ site.baseurl }}/agencies/">Agencies Supported</a></h4></li>
               <li><h4><a href="{{ site.baseurl }}/leadership/">Leadership Team</a></h4></li>
               <li><h4><a href="{{ site.baseurl }}/about/">About Us</a></h4></li>
-              
+
               <!-- <li><h4><a href="{{ baseurl }}/events/">Events</a></h4></li>-->
               <li><h4><a href="{{ site.baseurl }}/faq/">FAQs</a></h4></li>
             </ul>
@@ -95,13 +95,3 @@
 <script src="{{ site.baseurl }}/js/imagesloaded.pkgds.min.js"></script>
 <script src="{{ site.baseurl }}/js/isotope.pkgd.min.js"></script>
 <script src="{{ site.baseurl }}/js/main.js"></script>
-
-<!-- Google Tag Manager -->
-<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-TQXNND"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-TQXNND');</script>
-<!-- End Google Tag Manager -->

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,3 +1,13 @@
+<!-- Google Tag Manager -->
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-TQXNND"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-TQXNND');</script>
+<!-- End Google Tag Manager -->
+
 <header>
 
   <nav class="navbar navbar-default navbar-fixed-top nav-bg" id="navbar">


### PR DESCRIPTION
Resolves #121 

Revisions:

+ Per guidance from https://github.com/GSA/code-gov-web/issues/11 and https://developers.google.com/tag-manager/quickstart, moves Google Tag Manager code from bottom to top of `body`. Assumes all pages on the site use the default page layout, which they do. The default page layout includes both the footer (where the code used to be) and the header (where the code now resides), so I am ok with the new placement. Disclaimer: I know nothing about GTM.