### PR TITLE
Changed "Read Full Article" Link

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@ layout: default
           <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/3P5UFV8d364"></iframe>
           
         </div>-->
-        <h5>Read the full article <a href="https://medium.com/@WhiteHouse/meet-the-presidential-innovation-fellows-194dec20442b" target="_blank">here</a></h5>
+        <h5><a href="https://gsablogs.gsa.gov/gsablog/2017/11/30/meet-the-newest-presidential-innovation-fellows-2/" target="_blank">Learn more</a></h5>
         <br/>
       </div>
     </div>


### PR DESCRIPTION
Changed link text from "Read full article here" to "Learn more"
Changed link href from medium article to https://gsablogs.gsa.gov/gsablog/2017/11/30/meet-the-newest-presidential-innovation-fellows-2/