### PR TITLE
Update Application Timeframes

### DIFF
--- a/pages/faq.html
+++ b/pages/faq.html
@@ -19,7 +19,7 @@ permalink: faq/
 			<p>A: The Presidential Innovation Fellowship is a 12-month program, during which a Fellow will work on innovation projects across federal agencies.</p>
 			<hr/>
 			<h5><strong>Q: When can I apply?</strong></h5>
-			<p>A: We accept applications twice a year, once in the Spring, and once in the Fall. Please check apply.pif.gov for the current application deadline.</p>
+			<p>A: We accept applications once per year. Please check <a href="https://apply.pif.gov/" target="_blank">apply.pif.gov</a> for the current application deadline.</p>
 			<hr/>
 			<h5><strong>Q: Where is the Fellowship located?</strong></h5>
 			<p>A: Presidential Innovation Fellows are based in Washington, D.C. area for the duration of the Fellowship. Fellows will spend a portion of their time working at one of the federal agencies to which they are assigned, which are typically in Washington D.C. or the surrounding areas. Additionally, Fellows occasionally co-work and collaborate on projects in space provided by the General Services Administration.</p>


### PR DESCRIPTION
Replaced "twice a year, once in the Spring, and once in the Fall" with "once per year".

Made the "apply.pif.gov" text into a hyperlink which also links to that address.