### PR TITLE
Hide announcement

### DIFF
--- a/pages/announcement.html
+++ b/pages/announcement.html
@@ -2,6 +2,7 @@
 layout: default
 title: Job Announcement
 permalink: announcement/
+published: false
 ---
 <div class="container-fluid" id="hero">
 	<div class="row">
@@ -11,7 +12,7 @@ permalink: announcement/
 	</div>
 </div>
 <div class="container" id="announcement">
-	<div class="row">		
+	<div class="row">
 		<div class="col-md-10 col-md-offset-1">
 			<h4><strong>Job Title:</strong> Presidential Innovation Fellow</h4>
 			<h4><strong>Agency:</strong> General Services Administration</h4>

--- a/pages/faq.html
+++ b/pages/faq.html
@@ -14,7 +14,7 @@ permalink: faq/
 <div class="container" id="faq">
 	<div class="row">
 		<div class="col-md-10 col-md-offset-1">
-			<h3><a href="{{ site.baseurl }}/announcement">Official Job Announcement</a></h3>
+			<!--h3><a href="{{ site.baseurl }}/announcement">Official Job Announcement</a></h3-->
 			<h5><strong>Q: How long is the Fellowship?</strong></h5>
 			<p>A: The Presidential Innovation Fellowship is a 12-month program, during which a Fellow will work on innovation projects across federal agencies.</p>
 			<hr/>


### PR DESCRIPTION
Revisions:

  + Removes announcement link from FAQ page
  + Un-publishes the announcement page, so even if someone visits the URL manually, they won't find the page.

<hr>
Removes link:

<img width="806" alt="screen shot 2018-02-05 at 2 58 45 pm" src="https://user-images.githubusercontent.com/1328807/35825911-43a3de7a-0a85-11e8-918b-978f105964c9.png">

<hr>

Un-publishes page:
<img width="914" alt="screen shot 2018-02-05 at 2 58 40 pm" src="https://user-images.githubusercontent.com/1328807/35825910-43690fde-0a85-11e8-9697-15c17525cbd1.png">

