### PR TITLE
Remove Clay Johnson from Fellows page

### DIFF
--- a/_data/fellows/johnson-clay.yml
+++ b/_data/fellows/johnson-clay.yml
@@ -1,7 +1,0 @@
-id: johnson-clay
-name: Clay Johnson
-img: johnson-clay-headshot.png
-year: 2012
-hometown: "Washington, DC"
-region: south
-skills:


### PR DESCRIPTION
This removes the data for Clay Johnson that appears on the Fellows page.