### PR TITLE
Add PIF Jobs mailing list

### DIFF
--- a/pages/application-temp.html
+++ b/pages/application-temp.html
@@ -3,4 +3,4 @@ layout: default
 title: Application Closed
 permalink: application-closed/
 ---
-<h3 style="text-align:center;margin-left:50px; margin-right:50px;margin-top:200px;margin-bottom:800px;">Thank you for your interest in the Presidential Innovation Fellows program! Formal applications for the Fall 2018 cohort of Fellows are now closed. However, if you are interested in the PIF program or other opportunities with the Technology Transformation Service,  join our mailing list <a href="https://goo.gl/forms/jhrJ5rgxH5lZsfBn1">here</a>.</h1>
+<h3 style="text-align:center;margin-left:50px; margin-right:50px;margin-top:200px;margin-bottom:800px;">Thank you for your interest in the Presidential Innovation Fellows program! Formal applications for the Fall 2018 cohort of Fellows are now closed. However, if you are interested in the PIF program or other opportunities with the Technology Transformation Service, join our mailing list <a href="https://public.govdelivery.com/accounts/USGSATTS/subscriber/new?topic_id=USGSATTS_4">here</a>.</h1>


### PR DESCRIPTION
To replace the old google form. 

This is a quick fix, but you could also consider adding an embedded email sign up form to this page to reduce the number of steps for users. 