### PR TITLE
Update to USWDS 2.8.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,9 +17,10 @@ gem "jekyll", "~> 3.8"
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.6"
   gem 'jekyll-redirect-from'
-  gem 'jekyll-paginate-v2', "2.0"  
+  gem 'jekyll-paginate-v2', "2.0"
   gem 'jekyll-sitemap'
   gem 'jekyll-seo-tag'
+  gem 'jekyll-autoprefixer'
   gem "jekyll-assets", "~> 3.0", group: :jekyll_plugins
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    autoprefixer-rails (9.8.5)
+      execjs
     colorator (1.1.0)
     colorize (0.8.1)
     concurrent-ruby (1.1.6)
@@ -66,6 +68,8 @@ GEM
       nokogiri (~> 1.8)
       pathutil (~> 0.16)
       sprockets (>= 3.3, < 4.1.beta)
+    jekyll-autoprefixer (1.0.2)
+      autoprefixer-rails (~> 9.3)
     jekyll-feed (0.11.0)
       jekyll (~> 3.3)
     jekyll-paginate-v2 (2.0.0)
@@ -141,6 +145,7 @@ DEPENDENCIES
   html-proofer (~> 3.10)
   jekyll (~> 3.8)
   jekyll-assets (~> 3.0)
+  jekyll-autoprefixer
   jekyll-feed (~> 0.6)
   jekyll-paginate-v2 (= 2.0)
   jekyll-redirect-from
@@ -152,4 +157,4 @@ RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/_assets/css/_uswds-pif-theme-colors.scss
+++ b/_assets/css/_uswds-pif-theme-colors.scss
@@ -56,4 +56,5 @@ $theme-color-secondary-dark: "blue-warm-70";
 $theme-color-secondary-darker: "blue-warm-80";
 $theme-color-secondary-darkest: "blue-cool-80v";
 
-$theme-button: "gold-40v";
+$theme-banner-link-color: "secondary-dark";
+$theme-breadcrumb-link-color: "secondary-dark";

--- a/_assets/css/_uswds-pif-theme-colors.scss
+++ b/_assets/css/_uswds-pif-theme-colors.scss
@@ -58,3 +58,4 @@ $theme-color-secondary-darkest: "blue-cool-80v";
 
 $theme-banner-link-color: "secondary-dark";
 $theme-breadcrumb-link-color: "secondary-dark";
+$theme-banner-max-width: "none";

--- a/_assets/css/_uswds-pif-theme-colors.scss
+++ b/_assets/css/_uswds-pif-theme-colors.scss
@@ -56,6 +56,7 @@ $theme-color-secondary-dark: "blue-warm-70";
 $theme-color-secondary-darker: "blue-warm-80";
 $theme-color-secondary-darkest: "blue-cool-80v";
 
+$theme-button: "gold-40v";
 $theme-banner-link-color: "secondary-dark";
 $theme-breadcrumb-link-color: "secondary-dark";
 $theme-banner-max-width: "none";

--- a/_assets/css/_uswds-theme-custom-styles.scss
+++ b/_assets/css/_uswds-theme-custom-styles.scss
@@ -327,15 +327,10 @@ USWDS - PIF THEME STYLES
     width: 100%;
   }
 }
-.usa-banner__inner {
-  @include u-padding-x(2);
-  margin: 0;
+.usa-banner__inner, .usa-banner__content {
   @include at-media('desktop') {
     @include u-padding-x(6);
   }
-}
-.usa-banner__content {
-  display: hidden;
 }
 .usa-sidenav {
   a, .usa-current {

--- a/_config.yml
+++ b/_config.yml
@@ -114,7 +114,6 @@ plugins:
 # Site configuration for the Jekyll 3 Pagination Gem
 # The values here represent the defaults if nothing is set
 pagination:
-
   # Site-wide kill switch, disabled here it doesn't run at all
   enabled: true
 
@@ -202,3 +201,10 @@ assets:
     - node_modules/uswds/dist/img
     - node_modules/uswds/dist/js
     - node_modules/uswds/dist/scss
+
+autoprefixer:
+  browsers:
+    - last 2 versions
+    - "> 2%"
+    - IE 11
+    - not dead


### PR DESCRIPTION
Hi — this updates a couple settings to update the PIF site to USWDS 2.8.0

- Adds `$theme-banner-link-color: "secondary-dark";` to fix a contrast error in the banner code
- Adds `$theme-breadcrumb-link-color: "secondary-dark";` to fix a contrast issue in the breadcrumb code
- Adds `$theme-banner-max-width: "none";` to fix an issue with the banner display
- Adds custom banner spacing to the banner content
- Adds an autoprefixer to your compiler to use proper cross-browser rules